### PR TITLE
EDGE-899 #comment added setting of parser->nread

### DIFF
--- a/http_parser.c
+++ b/http_parser.c
@@ -1785,6 +1785,7 @@ reexecute:
          * we have to simulate it by handling a change in errno below.
          */
         if (settings->on_headers_complete) {
+          parser->nread = nread;
           switch (settings->on_headers_complete(parser)) {
             case 0:
               break;


### PR DESCRIPTION
Restores nread functionality so that it is reported correctly when the on_headers_complete callback is performed.